### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/moscaen/e8ee78c4-e8b8-4bb9-b319-3ba4b2ad6720/7a1a78cd-7c77-4109-b00c-87aa69a84884/_apis/work/boardbadge/6250eb75-9c1c-4572-bb30-9aeb2185af4e)](https://dev.azure.com/moscaen/e8ee78c4-e8b8-4bb9-b319-3ba4b2ad6720/_boards/board/t/7a1a78cd-7c77-4109-b00c-87aa69a84884/Microsoft.RequirementCategory)
 # AZ-400-DEVOPS-EXPERT guide - Table of contents
 
 - [AZ-400-DEVOPS-EXPERT guide - Table of contents](#az-400-devops-expert-guide---table-of-contents)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/moscaen/e8ee78c4-e8b8-4bb9-b319-3ba4b2ad6720/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.